### PR TITLE
Made placeholder URLs on homepage into links.

### DIFF
--- a/app/views/nice/index.html.erb
+++ b/app/views/nice/index.html.erb
@@ -8,15 +8,15 @@
     <div class="header">The only image placeholder service on the web bringing you nothing but Vanilla Ice jpgs. You're welcome.</div>
     <div class="examples">Examples:</div>
     <div class="example">
-        <div class="header">http://nicenicejpg.com/600/400</div>
+        <div class="header"><a href="http://nicenicejpg.com/600/400" target="_blank">http://nicenicejpg.com/600/400</a></div>
         <div class="description">Standard placeholder behavior: The first parameter represents the width, the second parameter is the height. This URL will return a 600-pixel-wide by 400-pixel-tall picture of Mr. Van Winkle.</div>
     </div>
     <div class="example">
-        <div class="header">http://nicenicejpg.com/350</div>
+        <div class="header"><a href="http://nicenicejpg.com/350" target="_blank">http://nicenicejpg.com/350</a></div>
         <div class="description">Returns a square image of Vanilla with width and height of 350 pixels.</div>
     </div>
     <div class="example">
-        <div class="header">http://nicenicejpg.com/5.0/300/200</div>
+        <div class="header"><a href="http://nicenicejpg.com/5.0/300/200" target="_blank">http://nicenicejpg.com/5.0/300/200</a></div>
         <div class="description">A special treat: Preface the width and height with "5.0" to switch into "Early 90's Mustang" mode.</div>
     </div>
 </div>


### PR DESCRIPTION
I came across NiceNiceJPG, and soon after clicked on one of the placeholder URLs on the homepage to try it out. It wasnt a link, but it should be.
